### PR TITLE
remove outdated note about cost of clojurebridge.org email addresses

### DIFF
--- a/checklist_for_new_board.md
+++ b/checklist_for_new_board.md
@@ -31,5 +31,3 @@ Additionally,
 
 #### Google Apps account
 - should have xxx@clojurebridge.org email account at Google Apps
-
-  [Note] $5/person each month will be added up to a current charge.


### PR DESCRIPTION
Closes #10
