### PR TITLE
remove references to Trello

### DIFF
--- a/ClojureBridge Stuff & Where it Lives.md
+++ b/ClojureBridge Stuff & Where it Lives.md
@@ -6,7 +6,6 @@ All accounts are free unless otherwise noted.
 
 | Account | Who Has the Credentials | Notes |
 |---------|-------------------------|-------|
-| Trello  | Yoko                    | Owner's cred is shared. Each member has his/her own account. Used for core meeting agendas. |
 | Twitter | Yoko                    | @ClojureBridge |
 | Mailchimp | Bridget, Jen, Jamie    | Email response(?) when people subscribe on clojurebridge.org |
 | G Suite[[*1]](#googleapps) | Each memember  | All board members have name@clojurebridge.org email. Passwords are their own password. |

--- a/checklist_for_new_board.md
+++ b/checklist_for_new_board.md
@@ -20,10 +20,5 @@ privileges listed below
 Additionally,
 - tell her/him to subscribe clojurebridge-curriculum if interested
 
-#### trello board
-- should have access to trello board, ClojureBridge Core Meeting Agendas
-  1. Add to the board <http://help.trello.com/article/717-adding-people-to-a-board>
-  2. Add to the team <http://help.trello.com/article/715-inviting-people-to-an-organization>
-
 #### Google Apps account
 - should have xxx@clojurebridge.org email account at Google Apps


### PR DESCRIPTION
Tracking issues on GitHub is working well for us. Let's remove references to Trello to avoid confusion.
